### PR TITLE
Parse babelrc for babel-register

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3565,6 +3565,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3573,14 +3581,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7580,6 +7580,14 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7588,14 +7596,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -45,8 +45,10 @@ if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging' 
     // Get babelrc file because the ignore property isn't recognized by default
     // see https://github.com/babel/babel/issues/4082
     babelrc = JSON.parse(fs.readFileSync(babelrcPath, 'utf8'));
+    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
     require('babel-register')(babelrc);
   } catch (e) {
+    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
     require('babel-register');
   }
 }

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -40,11 +40,10 @@ if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging' 
   dirname = path.join(process.cwd(), 'build');
 } else {
   const babelrcPath = path.join(process.cwd(), '.babelrc');
-  let babelrc;
   try {
     // Get babelrc file because the ignore property isn't recognized by default
     // see https://github.com/babel/babel/issues/4082
-    babelrc = JSON.parse(fs.readFileSync(babelrcPath, 'utf8'));
+    const babelrc = JSON.parse(fs.readFileSync(babelrcPath, 'utf8'));
     // eslint-disable-next-line global-require, import/no-extraneous-dependencies
     require('babel-register')(babelrc);
   } catch (e) {

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -39,8 +39,16 @@ let dirname = path.join(process.cwd(), 'src');
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging' || argv.built) {
   dirname = path.join(process.cwd(), 'build');
 } else {
-  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-  require('babel-register');
+  const babelrcPath = path.join(process.cwd(), '.babelrc');
+  let babelrc;
+  try {
+    // Get babelrc file because the ignore property isn't recognized by default
+    // see https://github.com/babel/babel/issues/4082
+    babelrc = JSON.parse(fs.readFileSync(babelrcPath, 'utf8'));
+    require('babel-register')(babelrc);
+  } catch (e) {
+    require('babel-register');
+  }
 }
 
 try {


### PR DESCRIPTION
This was to allow us to pass the ignore property to babel-register. It is not inherently propagated by default. See https://github.com/babel/babel/issues/4082 for more info.

I'm not sure if I should version bump here and what type it would be, so please advise.