### PR TITLE
Revert "Parse babelrc for babel-register"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3565,14 +3565,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3581,6 +3573,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7580,14 +7580,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7596,6 +7588,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -39,17 +39,8 @@ let dirname = path.join(process.cwd(), 'src');
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging' || argv.built) {
   dirname = path.join(process.cwd(), 'build');
 } else {
-  const babelrcPath = path.join(process.cwd(), '.babelrc');
-  try {
-    // Get babelrc file because the ignore property isn't recognized by default
-    // see https://github.com/babel/babel/issues/4082
-    const babelrc = JSON.parse(fs.readFileSync(babelrcPath, 'utf8'));
-    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-    require('babel-register')(babelrc);
-  } catch (e) {
-    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-    require('babel-register');
-  }
+  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+  require('babel-register');
 }
 
 try {


### PR DESCRIPTION
Reverts gas-buddy/service#31

After installing and trying to ignore certain node modules, I was receiving errors like the following that I wasn't able to resolve.

```
error: consumer-web failed to start Error: Options {"loose":true} passed to /Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/node_modules/babel-preset-env/lib/index.js which does not accept options. (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/node_modules/babel-preset-env/lib/index.js") (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/node_modules/babel-preset-env/lib/index.js") (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/index.js") (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/index.js") (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/index.js") (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/index.js") (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/index.js") (While processing preset: "/Users/jsmith/Code/consumer-web/node_modules/babel-preset-gasbuddy/index.js")
    at /Users/jsmith/Code/consumer-web/node_modules/babel-core/lib/transformation/file/options/option-manager.js:314:17
    at Array.map (<anonymous>)
    at OptionManager.resolvePresets (/Users/jsmith/Code/consumer-web/node_modules/babel-core/lib/transformation/file/options/option-manager.js:275:20)
    at OptionManager.mergePresets (/Users/jsmith/Code/consumer-web/node_modules/babel-core/lib/transformation/file/options/option-manager.js:264:10)
    at OptionManager.mergeOptions (/Users/jsmith/Code/consumer-web/node_modules/babel-core/lib/transformation/file/options/option-manager.js:249:14)
    at OptionManager.init (/Users/jsmith/Code/consumer-web/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at compile (/Users/jsmith/Code/consumer-web/node_modules/babel-register/lib/node.js:103:45)
    at loader (/Users/jsmith/Code/consumer-web/node_modules/babel-register/lib/node.js:144:14)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/jsmith/Code/consumer-web/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at /Users/jsmith/Code/consumer-web/node_modules/babel-core/lib/transformation/file/options/option-manager.js:296:17
    at Array.map (<anonymous>)
```