### PR TITLE
Don't log huge amounts of source code when hydration fails.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, winston, express, confit, ES7 and tap.",
   "main": "build/index.js",
   "scripts": {

--- a/src/Service.js
+++ b/src/Service.js
@@ -130,7 +130,7 @@ export default class Service extends EventEmitter {
       }
     } catch (error) {
       // eslint-disable-next-line no-console
-      winston.error('@gasbuddy/service hydration failed', error);
+      winston.error('@gasbuddy/service hydration failed', this.wrapError(error));
       throw error;
     }
   }


### PR DESCRIPTION
There are functions on that `error` object, and logging them prints their full source code to the terminal.