### PR TITLE
split out method from path in superagent metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/superagentHelper.js
+++ b/src/superagentHelper.js
@@ -12,7 +12,7 @@ export function superagentFunctor(service, req, logger) {
       superagentHistogram = new service.metrics.Histogram(
         'superagent_http_requests',
         'Outbound SuperAgent requests',
-        ['status', 'source', 'endpoint'],
+        ['status', 'source', 'endpoint', 'method'],
       );
     }
 
@@ -35,7 +35,8 @@ export function superagentFunctor(service, req, logger) {
         superagentHistogram.observe({
           source: service.name,
           status: newRequest.res ? newRequest.res.statusCode : 0,
-          endpoint: `${method}_${loggableUrl || url}`,
+          endpoint: loggableUrl || url,
+          method: method.toUpperCase(),
         }, dur);
       }
     });
@@ -47,14 +48,15 @@ export function superagentFunctor(service, req, logger) {
         superagentHistogram.observe({
           source: service.name,
           status: error.status,
-          endpoint: `${method}_${loggableUrl || url}`,
+          endpoint: loggableUrl || url,
+          method: method.toUpperCase(),
         }, dur);
       }
       if (logErrors) {
         newLogger.error('Http request failed', {
           status: error.status,
           url: loggableUrl || url,
-          method,
+          method: method.toUpperCase(),
           dur,
         });
       }

--- a/tests/test_app.js
+++ b/tests/test_app.js
@@ -156,6 +156,7 @@ tap.test('server startup', async (t) => {
   const res = await request(s.service.metrics.app)
     .get('/metrics');
   t.match(res.text, /superagent_http_requests_bucket/, 'Should have a superagent metric');
+  t.match(res.text, /superagent_http_requests_sum{[^}]+\bmethod=[^}]+}/, 'Superagent metric should have a method');
   t.match(res.text, /# TYPE test_metric counter/, 'Should have our counter');
   t.match(res.text, /test_metric 101/, 'Should have our counter value');
   t.match(res.text, /faker_count{source="pet-serv",success="true"}/, 'Should have faker');


### PR DESCRIPTION
There may be a reason for this being in here but I'm submitting the change to make this consistent with `service_requests` labels (including the uppercasing of the `method`). Feel free to close if I'm overlooking something.