### PR TITLE
Log the error stack when a service/application fails to start

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -97,7 +97,7 @@ export default class Server {
         this.service.logger.error(`${this.service.name} failed to start`, loggableError(error));
       } else {
         // eslint-disable-next-line no-console
-        console.error(`${this.service.name} failed to start, and failed to configure the logger: ${error}`);
+        console.error(`${this.service.name} failed to start, and failed to configure the logger: ${error.message}\n\n${error.stack}`);
       }
       throw error;
     }


### PR DESCRIPTION
We've been working through new tooling and come across logging like this
```
[10:39:38.032 AM] INFO : Configured pino logging
[10:39:38.135 AM] INFO : Read GBAPI_USERNAME environment variable from .env
[10:39:38.136 AM] INFO : Read GBAPI_PASSWORD environment variable from .env
[10:39:38.136 AM] INFO : Read GBAPI_HMAC_KEY environment variable from .env
[10:39:38.136 AM] INFO : Read FACEBOOK_APPID environment variable from .env
[10:39:38.136 AM] INFO : Read FACEBOOK_SECRET environment variable from .env
[10:39:38.136 AM] INFO : Starting identity-web from /Users/jsmith/Code/identity-web/src
identity-web failed to start, and failed to configure the logger: Unexpected token export
```

This generally isn't helpful without knowing where the error was thrown, so I've added a stack trace log that results in this
```
[10:39:38.032 AM] INFO : Configured pino logging
[10:39:38.135 AM] INFO : Read GBAPI_USERNAME environment variable from .env
[10:39:38.136 AM] INFO : Read GBAPI_PASSWORD environment variable from .env
[10:39:38.136 AM] INFO : Read GBAPI_HMAC_KEY environment variable from .env
[10:39:38.136 AM] INFO : Read FACEBOOK_APPID environment variable from .env
[10:39:38.136 AM] INFO : Read FACEBOOK_SECRET environment variable from .env
[10:39:38.136 AM] INFO : Starting identity-web from /Users/jsmith/Code/identity-web/src
identity-web failed to start, and failed to configure the logger: Unexpected token export

/Users/jsmith/Code/identity-web/node_modules/@gasbuddy/dom-telemetry/src/index.js:1
(function (exports, require, module, __filename, __dirname) { export * from './Criteo';
                                                              ^^^^^^

SyntaxError: Unexpected token export
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:616:28)
    at Module._compile (/Users/jsmith/Code/identity-web/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (module.js:663:10)
    at Object.newLoader [as .js] (/Users/jsmith/Code/identity-web/node_modules/pirates/lib/index.js:104:7)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/jsmith/Code/identity-web/src/lib/utils.js:1:1)
    at Module._compile (module.js:652:30)
    at Module._compile (/Users/jsmith/Code/identity-web/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (module.js:663:10)
    at Object.newLoader [as .js] (/Users/jsmith/Code/identity-web/node_modules/pirates/lib/index.js:104:7)
```

If this is too verbose for staging/production environments, let me know and I'll only log the stack conditionally.