### PR TITLE
Fix Invalid Date in an error.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "10.7.1",
+  "version": "10.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "10.7.1",
+  "version": "10.7.2",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, pino logging, express, confit, ES7 and tap.",
   "main": "build/index.js",
   "scripts": {

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ import { superagentFunctor } from './superagentHelper';
  */
 function normalizeError(error) {
   const isError = error instanceof Error;
-
+  delete error.time;
   if (isError) {
     return error;
   }

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ import { superagentFunctor } from './superagentHelper';
  */
 function normalizeError(error) {
   const isError = error instanceof Error;
-  
+
   if (isError) {
     delete error.time;
     return error;

--- a/src/util.js
+++ b/src/util.js
@@ -5,8 +5,9 @@ import { superagentFunctor } from './superagentHelper';
  */
 function normalizeError(error) {
   const isError = error instanceof Error;
-  delete error.time;
+  
   if (isError) {
+    delete error.time;
     return error;
   }
 


### PR DESCRIPTION
Steps to recreate Pino error:

1.  Have an service / sdk that returns a "time" property in an error.   AWS-SDK is a good example.
If that time is a string and not a date object, then this will cause an Invalid Date error with a stack trace like this.

There might also be a setting on the configured Pino client we could set

TypeError: Invalid date\n    at /data/node_modules/dateformat/lib/dateformat.js:39:17\n    at formatTime (/data/node_modules/pino-pretty/lib/utils.js:72:12)\n    at prettifyTime (/data/node_modules/pino-pretty/lib/utils.js:372:18)\n    at pretty (/data/node_modules/pino-pretty/index.js:89:28)\n    at Object.write (/data/node_modules/pino/lib/tools.js:277:25)\n    at Pino.write (/data/node_modules/pino/lib/proto.js:171:15)\n    at Pino.LOG [as error] (/data/node_modules/pino/lib/tools.js:55:21)\n    at WrappedLogger.error (/data/node_modules/@gasbuddy/configured-pino/src/WrappedLogger.js:148:6)\n    at GbService.configure (/data/node_modules/@gasbuddy/service/src/Service.js:190:25)