### PR TITLE
Properly load routes for apps using javascript file as entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "12.20.0",
+  "version": "12.20.1",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, pino logging, express, confit, Typescript and Jest.",
   "main": "build/index.js",
   "scripts": {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -126,6 +126,7 @@ export async function bootstrap<
     rootDirectory,
     service: impl.default || impl.service,
     codepath,
+    useJsEntrypoint,
   };
   const { startApp, listen } = await import('./express-app/app.js');
   const app = await startApp<SLocals, RLocals>(opts);

--- a/src/express-app/app.ts
+++ b/src/express-app/app.ts
@@ -87,7 +87,7 @@ export async function startApp<
   RLocals extends RequestLocals = RequestLocals,
 >(startOptions: ServiceStartOptions<SLocals, RLocals>): Promise<ServiceExpress<SLocals>> {
   const {
-    service, rootDirectory, codepath = 'build', name,
+    service, rootDirectory, codepath = 'build', name, useJsEntrypoint,
   } = startOptions;
   const shouldPrettyPrint = isDev() && !process.env.NO_PRETTY_LOGS;
   const destination = pino.destination({
@@ -258,10 +258,11 @@ export async function startApp<
   }
 
   if (routing?.routes) {
+    const routeFileExtension = useJsEntrypoint ? 'js' : 'ts';
     await loadRoutes(
       app,
       path.resolve(rootDirectory, codepath, config.get('routing:routes')),
-      codepath === 'build' ? '**/*.js' : '**/*.ts',
+      codepath === 'build' ? '**/*.js' : `**/*.${routeFileExtension}`,
     );
   }
   if (routing?.openapi) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,8 @@ export interface ServiceStartOptions<
   // locals: { stuff } as Partial<MyLocals>
   locals?: Partial<SLocals>;
 
+  useJsEntrypoint?: boolean;
+
   // And finally, the function that creates the service instance
   service: () => Service<SLocals, RLocals>;
 }


### PR DESCRIPTION
This was something left out of sight and just recently caught. Per current setup, for apps using javascript file as entrypoint in development mode, the routes would be ignored. This change fixes it and makes the service consider loading route files properly based on entrypoint spec on start-service command.