### PR TITLE
[WIP] Support configuration overrides at startup

### DIFF
--- a/__tests__/fake-serv.test.ts
+++ b/__tests__/fake-serv.test.ts
@@ -70,20 +70,23 @@ describe('fake-serv', () => {
   });
 
   test('allow configuration modification before starting service', async () => {
+    let configSpy;
+
     const options: ServiceStartOptions<FakeServLocals> = {
       service: fakeServ,
       name: 'fake-serv',
       rootDirectory: path.resolve(__dirname, './fake-serv'),
       codepath: 'src',
-      onConfigurationLoaded: (app) => {
-        Object.assign(app.locals.config, {
+      configChanges: (app) => {
+        configSpy = jest.spyOn(app.locals.config, 'get');
+        return {
           logging: {
+            ...app.locals.config.get('logging'),
             level: 'warn',
           },
-        });
+        };
       },
     };
-    const configSpy = jest.spyOn(options, 'onConfigurationLoaded');
 
     const app = await startApp(options).catch((error) => {
       console.error(error);

--- a/src/bin/start-service.ts
+++ b/src/bin/start-service.ts
@@ -12,7 +12,7 @@ import { bootstrap } from '../bootstrap';
  * nobind - do not listen on http port or expose metrics
  */
 const argv = minimist(process.argv.slice(2), {
-  boolean: ['built', 'repl', 'telemetry', 'nobind'],
+  boolean: ['built', 'repl', 'telemetry', 'nobind', 'useJsEntrypoint'],
 });
 
 const noTelemetry = (argv.repl || isDev()) && !argv.telemetry;

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -25,8 +25,8 @@ interface BootstrapArguments {
   nobind?: boolean;
   // Specify whether the app wants to use a src/index.js as entrypoint instead of a src/index.ts
   useJsEntrypoint?: boolean;
-  // Handle configuration changes for service configuration before actually starting the app
-  onConfigurationLoaded?: (app: ServiceExpress<ServiceLocals>) => void;
+  // Provide configuration changes to be overwritten before actually starting the app
+  configChanges?: (app: ServiceExpress<ServiceLocals>) => Record<string, any>;
 }
 
 function resolveMain(packageJson: NormalizedPackageJson) {
@@ -45,7 +45,7 @@ async function getServiceDetails(argv: BootstrapArguments = {}) {
       name: argv.name,
       main: argv.main || (isDev() && !argv.built ? `src/index.${useJsEntrypoint ? 'j' : 't'}s` : 'build/index.js'),
       useJsEntrypoint,
-      onConfigurationLoaded: argv.onConfigurationLoaded,
+      configChanges: argv.configChanges,
     };
   }
   const cwd = argv.packageDir ? path.resolve(argv.packageDir) : process.cwd();
@@ -62,7 +62,7 @@ async function getServiceDetails(argv: BootstrapArguments = {}) {
     rootDirectory: path.dirname(pkg.path),
     name: parts[parts.length - 1],
     useJsEntrypoint,
-    onConfigurationLoaded: argv.onConfigurationLoaded,
+    configChanges: argv.configChanges,
   };
 }
 
@@ -79,7 +79,7 @@ export async function bootstrap<
     rootDirectory,
     name,
     useJsEntrypoint,
-    onConfigurationLoaded,
+    configChanges,
   } = await getServiceDetails(argv);
 
   let entrypoint: string;
@@ -122,7 +122,6 @@ export async function bootstrap<
       name,
       rootDirectory,
       service: absoluteEntrypoint,
-      onConfigurationLoaded,
     });
   }
 
@@ -135,6 +134,7 @@ export async function bootstrap<
     service: impl.default || impl.service,
     codepath,
     useJsEntrypoint,
+    configChanges,
   };
   const { startApp, listen } = await import('./express-app/app.js');
   const app = await startApp<SLocals, RLocals>(opts);

--- a/src/express-app/app.ts
+++ b/src/express-app/app.ts
@@ -87,7 +87,12 @@ export async function startApp<
   RLocals extends RequestLocals = RequestLocals,
 >(startOptions: ServiceStartOptions<SLocals, RLocals>): Promise<ServiceExpress<SLocals>> {
   const {
-    service, rootDirectory, codepath = 'build', name, useJsEntrypoint,
+    service,
+    rootDirectory,
+    codepath = 'build',
+    name,
+    useJsEntrypoint,
+    onConfigurationLoaded,
   } = startOptions;
   const shouldPrettyPrint = isDev() && !process.env.NO_PRETTY_LOGS;
   const destination = pino.destination({
@@ -148,6 +153,13 @@ export async function startApp<
     config,
     name,
   });
+
+  // Allow consumers of the service to have a handle on configuration as soon as its initialized
+  // to request synchronous changes if needed
+  // This support is needed mostly for cronjobs and cli utilities
+  if (onConfigurationLoaded && typeof onConfigurationLoaded === 'function') {
+    onConfigurationLoaded(app);
+  }
 
   try {
     await enableMetrics(app, name);

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,8 @@ export interface ServiceStartOptions<
 
   // And finally, the function that creates the service instance
   service: () => Service<SLocals, RLocals>;
+
+  onConfigurationLoaded?: (app: ServiceExpress<SLocals>) => void,
 }
 
 export interface DelayLoadServiceStartOptions extends Omit<ServiceStartOptions, 'service'> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ export interface ServiceStartOptions<
   // And finally, the function that creates the service instance
   service: () => Service<SLocals, RLocals>;
 
-  onConfigurationLoaded?: (app: ServiceExpress<SLocals>) => void,
+  configChanges?: (app: ServiceExpress<SLocals>) => Record<string, any>,
 }
 
 export interface DelayLoadServiceStartOptions extends Omit<ServiceStartOptions, 'service'> {


### PR DESCRIPTION
The changes seem to apply overrides to config temporary, but what I observe is that when `gb.start` is called, the config overrides seem to go away and changes from config files are actually restored again. So, need to find where config changes from files get restored and make a fix there.