### PR TITLE
Add tracing headers to outgoing service calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "12.23.0",
+  "version": "12.23.1",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, pino logging, express, confit, Typescript and Jest.",
   "main": "build/index.js",
   "scripts": {

--- a/src/service-calls/index.ts
+++ b/src/service-calls/index.ts
@@ -1,4 +1,5 @@
 import { URL } from 'node:url';
+import crypto from 'node:crypto';
 import type { FetchConfig, FetchRequest, RestApiResponse } from 'rest-api-support';
 import EventSource from 'eventsource';
 import { ServiceError, ServiceErrorSpec } from '../error';
@@ -46,12 +47,20 @@ export function createServiceInterface<ServiceType>(
     config?.basePath || ''
   }`;
 
+  // Add tracing support across services using existing traceId or generating a new one
+  const tracingHeaders = {
+    headers: {
+      correlationid: service.locals.traceId || crypto.randomBytes(16).toString('hex'),
+    },
+  };
+
   const fetchConfig: FetchConfig = {
     fetch,
     AbortController,
     EventSource: CustomEventSource,
     FormData,
     baseUrl,
+    ...tracingHeaders,
   };
 
   // In development, it can be useful to route requests through
@@ -73,7 +82,7 @@ export function createServiceInterface<ServiceType>(
       parsedUrl.protocol = proxyUrl.protocol;
       parsedUrl.port = proxyUrl.port || proxyPort;
       // eslint-disable-next-line no-param-reassign
-      params.headers = params.headers || {};
+      params.headers = params.headers || { ...tracingHeaders.headers };
       Object.assign(params.headers, headers);
       // eslint-disable-next-line no-param-reassign
       params.url = parsedUrl.href;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface ServiceLocals {
   config: ConfigStore;
   meter: metrics.Meter;
   internalApp: Application<InternalLocals>;
+  traceId?: string;
 }
 
 export interface RequestLocals {


### PR DESCRIPTION
Adding a change to ensure `correlationid` is passed through headers with fetchConfig.