### PR TITLE
Changes to enable broader tracing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,3 +195,10 @@ to ameliorate as best as possible given the ubiquity of service calls. See [MIGR
 * Remove `runWithService` and `useService` hooks
 * Make logger customizable with additional metadata passed in args to apply to log bindings
 * Use single instance of `telemetry` for app startup
+
+12.24.0
+=======
+
+* Add currentTelemetryInfo helper for callers to use current telemetry info with regards to traceId, span and traceFlags
+* Update logger to ensure tracing info is injected using telemetry info if available
+* Ensure outgoing service calls use a default request interceptor to pass on correlationid in headers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "12.23.2",
+  "version": "12.24.0",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, pino logging, express, confit, Typescript and Jest.",
   "main": "build/index.js",
   "scripts": {

--- a/src/config/shortstops.ts
+++ b/src/config/shortstops.ts
@@ -45,7 +45,7 @@ function serviceTypeFactory(name: string) {
   return function serviceType(v: string) {
     let checkValue = v;
     let matchIsGood = true;
-    if (checkValue[0] === '!') {
+    if (checkValue.startsWith('!')) {
       matchIsGood = false;
       checkValue = checkValue.substring(1);
     }
@@ -100,7 +100,7 @@ export default function shortstops(
     env,
     // A version of env that can default to false
     env_switch(v: string) {
-      if (v && v[0] === '!') {
+      if (v && v.startsWith('!')) {
         const bval = env(`${v.substring(1)}|b`);
         return !bval;
       }

--- a/src/logger/getLogger.ts
+++ b/src/logger/getLogger.ts
@@ -40,6 +40,11 @@ export function getLogger(meta?: Record<string, any>) {
           colorize: true,
         },
       },
+      formatters: {
+        bindings(logInfo: pino.Bindings) {
+          return getBindings(logInfo, meta);
+        },
+      },
       mixin: ensureTracing,
     };
   } else {

--- a/src/logger/hooks.ts
+++ b/src/logger/hooks.ts
@@ -1,6 +1,4 @@
-import type {
-  Request, Response,
-} from 'express';
+import type { Request, Response } from 'express';
 import { getClientIp } from 'request-ip';
 import { ServiceError } from '../error';
 import type { ServiceExpress, ServiceLocals } from '../types';
@@ -9,10 +7,13 @@ import { LogPrefs } from './types';
 
 export function getBasicInfo(req: Request) {
   const url = req.originalUrl || req.url;
-
+  const ip = getClientIp(req);
+  const ua = req.headers['user-agent'];
   const preInfo: Record<string, string> = {
     url,
     m: req.method,
+    ...ip && { ip },
+    ...ua && { ua },
   };
 
   return preInfo;

--- a/src/logger/middleware.ts
+++ b/src/logger/middleware.ts
@@ -9,7 +9,7 @@ export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
   logRequests?: boolean,
   logResponses?: boolean,
 ): RequestHandler {
-  const { logger, service } = app.locals;
+  const { logger, service, traceId } = app.locals;
   return function gblogger(req, res, next) {
     const prefs: LogPrefs = {
       start: process.hrtime(),
@@ -45,7 +45,7 @@ export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
       ...getBasicInfo(req),
       ref: req.headers.referer || undefined,
       sid: (req as any).session?.id,
-      c: req.headers.correlationid || undefined,
+      c: req.headers.correlationid || traceId || undefined,
     };
     service.getLogFields?.(req as any, preLog);
     logger.info(preLog, 'pre');

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -44,7 +44,7 @@ async function startTelemetry(options: DelayLoadServiceStartOptions) {
           // This particular line is "GasBuddy" specific, in that we have a number
           // of services not yet on OpenTelemetry that look for this header instead.
           // Putting traceId gives us a "shot in heck" of useful searches.
-          if (!/^c:/m.test(request.headers)) {
+          if (!/^correlationid:/m.test(request.headers)) {
             const ctx = span.spanContext();
             // eslint-disable-next-line no-param-reassign
             additionalHeaders.correlationid = ctx.traceId;

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,4 +1,11 @@
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import {
+  diag,
+  DiagConsoleLogger,
+  DiagLogLevel,
+  trace,
+  context,
+  SpanContext,
+} from '@opentelemetry/api';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import * as opentelemetry from '@opentelemetry/sdk-node';
 
@@ -12,7 +19,10 @@ import type {
 } from '../types';
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+diag.setLogger(new DiagConsoleLogger(), {
+  suppressOverrideMessage: true,
+  logLevel: DiagLogLevel.INFO,
+});
 
 function getExporter() {
   if (['production', 'staging'].includes(process.env.APP_ENV || process.env.NODE_ENV || '')) {
@@ -34,9 +44,11 @@ async function startTelemetry(options: DelayLoadServiceStartOptions) {
           // This particular line is "GasBuddy" specific, in that we have a number
           // of services not yet on OpenTelemetry that look for this header instead.
           // Putting traceId gives us a "shot in heck" of useful searches.
-          if (!/^correlationid:/m.test(request.headers)) {
+          if (!/^c:/m.test(request.headers)) {
             const ctx = span.spanContext();
+            // eslint-disable-next-line no-param-reassign
             additionalHeaders.correlationid = ctx.traceId;
+            // eslint-disable-next-line no-param-reassign
             additionalHeaders.span = ctx.spanId;
           }
         },
@@ -73,4 +85,9 @@ export async function startWithTelemetry<
     app.locals.logger.info('OpenTelemetry shut down');
   });
   return { app, server };
+}
+
+export function currentTelemetryInfo(): SpanContext | undefined {
+  const currentSpan = trace.getSpan(context.active());
+  return currentSpan?.spanContext();
 }


### PR DESCRIPTION
- Add `currentTelemetryInfo` helper for callers to use current telemetry info with regards to traceId, span and traceFlags
- Update logger to ensure tracing info is injected using telemetry info if available
- Ensure outgoing service calls use a default request interceptor to pass on correlationid in headers