### PR TITLE
Fix duplicate telemetry registration and await resource attributes to settle at startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "12.24.0",
+  "version": "12.24.1",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, pino logging, express, confit, Typescript and Jest.",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@opentelemetry/instrumentation-net": "^0.31.3",
     "@opentelemetry/instrumentation-pg": "^0.35.2",
     "@opentelemetry/instrumentation-pino": "^0.33.3",
+    "@opentelemetry/resources": "^1.27.0",
     "@opentelemetry/sdk-metrics": "^1.13.0",
     "@opentelemetry/sdk-node": "^0.39.1",
     "@opentelemetry/semantic-conventions": "^1.13.0",

--- a/src/logger/middleware.ts
+++ b/src/logger/middleware.ts
@@ -3,6 +3,7 @@ import type { ServiceExpress, ServiceLocals } from '../types';
 import { LogPrefs } from './types';
 import { LOG_PREFS } from './constants';
 import { finishLog, getBasicInfo } from './hooks';
+import { currentTelemetryInfo } from '../telemetry';
 
 export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
   app: ServiceExpress<SLocals>,
@@ -45,7 +46,7 @@ export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
       ...getBasicInfo(req),
       ref: req.headers.referer || undefined,
       sid: (req as any).session?.id,
-      c: req.headers.correlationid || traceId || undefined,
+      c: req.headers.correlationid || currentTelemetryInfo()?.traceId || traceId || undefined,
     };
     service.getLogFields?.(req as any, preLog);
     logger.info(preLog, 'pre');

--- a/src/service-calls/index.ts
+++ b/src/service-calls/index.ts
@@ -10,6 +10,7 @@ import type {
   ServiceLocals,
 } from '../types';
 import type { ServiceConfiguration } from '../config/schema';
+import { currentTelemetryInfo } from '../telemetry';
 
 class CustomEventSource extends EventSource {
   private activeListeners: Array<{ handler: (data: any) => void; name: string }> = [];
@@ -70,6 +71,7 @@ export function createServiceInterface<ServiceType>(
       const defaultPort = proto === 'https' ? 8443 : 8000;
       const headers: FetchRequest['headers'] = {
         correlationid: params.headers?.correlationid
+          || currentTelemetryInfo()?.traceId
           || service.locals.traceId
           || crypto.randomBytes(16).toString('hex'),
       };
@@ -91,6 +93,7 @@ export function createServiceInterface<ServiceType>(
     params.headers = params.headers || {};
     const headers: FetchRequest['headers'] = {
       correlationid: params.headers?.correlationid
+        || currentTelemetryInfo()?.traceId
         || service.locals.traceId
         || crypto.randomBytes(16).toString('hex'),
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,6 +1305,7 @@ __metadata:
     "@opentelemetry/instrumentation-net": ^0.31.3
     "@opentelemetry/instrumentation-pg": ^0.35.2
     "@opentelemetry/instrumentation-pino": ^0.33.3
+    "@opentelemetry/resources": ^1.27.0
     "@opentelemetry/sdk-metrics": ^1.13.0
     "@opentelemetry/sdk-node": ^0.39.1
     "@opentelemetry/semantic-conventions": ^1.13.0
@@ -1829,6 +1830,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/core@npm:1.27.0":
+  version: 1.27.0
+  resolution: "@opentelemetry/core@npm:1.27.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": 1.27.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 33ff551f89f0bb95830c9f9464c43b11adf88882ec1d3a03a5b9afcc89d2aafab33c36cb5047f18667d7929d6ab40ed0121649c42d0105f1cb33ffdca48f8b13
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-jaeger@npm:1.13.0":
   version: 1.13.0
   resolution: "@opentelemetry/exporter-jaeger@npm:1.13.0"
@@ -2180,6 +2192,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/resources@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "@opentelemetry/resources@npm:1.27.0"
+  dependencies:
+    "@opentelemetry/core": 1.27.0
+    "@opentelemetry/semantic-conventions": 1.27.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 43d298afea7daf7524e6b98c1441bcce9fa73b76aecf17e36cabb1a4cfaae6818acf9759d3e42706b1fd91243644076d2291e78c3ed81641d3b351fcff6cb9a9
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-logs@npm:0.39.1":
   version: 0.39.1
   resolution: "@opentelemetry/sdk-logs@npm:0.39.1"
@@ -2261,6 +2285,13 @@ __metadata:
   version: 1.13.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.13.0"
   checksum: 9cccf1d73315fed3920bb2201c0e82f66e58dddfa475314b6613780c2804570d6f657be3894eb8b84a2a543c9b8cd520587f5d6cd4b62bc6731d7299b4c5ee69
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.27.0":
+  version: 1.27.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.27.0"
+  checksum: 26d85f8d13c8c64024f7a84528cff41d56afc9829e7ff8a654576404f8b2c1a9c264adcc6fa5a9551bacdd938a4a464041fa9493e0a722e5605f2c2ae6752398
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes to fix duplicate registration of telemtry producing errors in log at startup.

Also awaits resource attributes to settle at telemetry startup.