### PR TITLE
Remove traceId usage from app.locals, depend on traceId from telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "12.24.1",
+  "version": "12.24.2",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, pino logging, express, confit, Typescript and Jest.",
   "main": "build/index.js",
   "scripts": {

--- a/src/express-app/app.ts
+++ b/src/express-app/app.ts
@@ -195,7 +195,7 @@ export async function startApp<
   }
 
   if (serviceImpl.authorize) {
-    const authorize: RequestHandler = (req, res, next) => {
+    const authorize = (): RequestHandler => (req, res, next) => {
       let maybePromise: Promise<boolean> | boolean | undefined;
       try {
         maybePromise = serviceImpl.authorize?.(

--- a/src/express-app/app.ts
+++ b/src/express-app/app.ts
@@ -150,7 +150,7 @@ export async function startApp<
 
   // Allow the service to add locals, etc. We put this before the body parsers
   // so that the req can decide whether to save the raw request body or not.
-  const attachServiceLocals: RequestHandler = (req, res, next) => {
+  const attachServiceLocals = (): RequestHandler => (req, res, next) => {
     res.locals.logger = logger;
     let maybePromise: Promise<void> | void;
     try {

--- a/src/express-app/app.ts
+++ b/src/express-app/app.ts
@@ -150,7 +150,7 @@ export async function startApp<
 
   // Allow the service to add locals, etc. We put this before the body parsers
   // so that the req can decide whether to save the raw request body or not.
-  const attachServiceLocals = (): RequestHandler => (req, res, next) => {
+  const attachServiceLocals: RequestHandler = (req, res, next) => {
     res.locals.logger = logger;
     let maybePromise: Promise<void> | void;
     try {
@@ -195,7 +195,7 @@ export async function startApp<
   }
 
   if (serviceImpl.authorize) {
-    const authorize = (): RequestHandler => (req, res, next) => {
+    const authorize: RequestHandler = (req, res, next) => {
       let maybePromise: Promise<boolean> | boolean | undefined;
       try {
         maybePromise = serviceImpl.authorize?.(

--- a/src/logger/middleware.ts
+++ b/src/logger/middleware.ts
@@ -10,7 +10,7 @@ export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
   logRequests?: boolean,
   logResponses?: boolean,
 ): RequestHandler {
-  const { logger, service, traceId } = app.locals;
+  const { logger, service } = app.locals;
   return function gblogger(req, res, next) {
     const prefs: LogPrefs = {
       start: process.hrtime(),
@@ -46,7 +46,7 @@ export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
       ...getBasicInfo(req),
       ref: req.headers.referer || undefined,
       sid: (req as any).session?.id,
-      c: req.headers.correlationid || currentTelemetryInfo()?.traceId || traceId || undefined,
+      c: req.headers.correlationid || currentTelemetryInfo()?.traceId || undefined,
     };
     service.getLogFields?.(req as any, preLog);
     logger.info(preLog, 'pre');

--- a/src/service-calls/index.ts
+++ b/src/service-calls/index.ts
@@ -72,7 +72,6 @@ export function createServiceInterface<ServiceType>(
       const headers: FetchRequest['headers'] = {
         correlationid: params.headers?.correlationid
           || currentTelemetryInfo()?.traceId
-          || service.locals.traceId
           || crypto.randomBytes(16).toString('hex'),
       };
       headers.host = `${proto}.${parsedUrl.hostname}.${port || defaultPort}`;
@@ -94,7 +93,6 @@ export function createServiceInterface<ServiceType>(
     const headers: FetchRequest['headers'] = {
       correlationid: params.headers?.correlationid
         || currentTelemetryInfo()?.traceId
-        || service.locals.traceId
         || crypto.randomBytes(16).toString('hex'),
     };
     Object.assign(params.headers, headers);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,6 @@ export interface ServiceLocals {
   config: ConfigStore;
   meter: metrics.Meter;
   internalApp: Application<InternalLocals>;
-  traceId?: string;
 }
 
 export interface RequestLocals {


### PR DESCRIPTION
## Changes

- Remove usage of traceId from service/app locals

I added traceId in locals to help with setting correlationid in logs, but it seems it does end up putting a bad value for log continuation and depending on traceId from telemetry is more reliable.