### PR TITLE
Bring back app.locals.traceId for outgoing req logs to continue correlation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/service",
-  "version": "12.24.2",
+  "version": "12.24.3",
   "description": "An opinionated framework for building configuration driven services - web, api, or job. Uses swagger, pino logging, express, confit, Typescript and Jest.",
   "main": "build/index.js",
   "scripts": {

--- a/src/logger/hooks.ts
+++ b/src/logger/hooks.ts
@@ -4,16 +4,22 @@ import { ServiceError } from '../error';
 import type { ServiceExpress, ServiceLocals } from '../types';
 import { LOG_PREFS } from './constants';
 import { LogPrefs } from './types';
+import { currentTelemetryInfo } from '../telemetry';
 
 export function getBasicInfo(req: Request) {
   const url = req.originalUrl || req.url;
   const ip = getClientIp(req);
   const ua = req.headers['user-agent'];
+  const correlationid = req.headers.correlationid
+    || currentTelemetryInfo()?.traceId
+    || req.app?.locals?.traceId
+    || undefined;
   const preInfo: Record<string, string> = {
     url,
     m: req.method,
     ...ip && { ip },
     ...ua && { ua },
+    ...correlationid && { c: correlationid },
   };
 
   return preInfo;

--- a/src/logger/middleware.ts
+++ b/src/logger/middleware.ts
@@ -3,7 +3,6 @@ import type { ServiceExpress, ServiceLocals } from '../types';
 import { LogPrefs } from './types';
 import { LOG_PREFS } from './constants';
 import { finishLog, getBasicInfo } from './hooks';
-import { currentTelemetryInfo } from '../telemetry';
 
 export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
   app: ServiceExpress<SLocals>,
@@ -46,7 +45,6 @@ export function loggerMiddleware<SLocals extends ServiceLocals = ServiceLocals>(
       ...getBasicInfo(req),
       ref: req.headers.referer || undefined,
       sid: (req as any).session?.id,
-      c: req.headers.correlationid || currentTelemetryInfo()?.traceId || undefined,
     };
     service.getLogFields?.(req as any, preLog);
     logger.info(preLog, 'pre');

--- a/src/service-calls/index.ts
+++ b/src/service-calls/index.ts
@@ -72,6 +72,7 @@ export function createServiceInterface<ServiceType>(
       const headers: FetchRequest['headers'] = {
         correlationid: params.headers?.correlationid
           || currentTelemetryInfo()?.traceId
+          || service.locals.traceId
           || crypto.randomBytes(16).toString('hex'),
       };
       headers.host = `${proto}.${parsedUrl.hostname}.${port || defaultPort}`;
@@ -93,6 +94,7 @@ export function createServiceInterface<ServiceType>(
     const headers: FetchRequest['headers'] = {
       correlationid: params.headers?.correlationid
         || currentTelemetryInfo()?.traceId
+        || service.locals.traceId
         || crypto.randomBytes(16).toString('hex'),
     };
     Object.assign(params.headers, headers);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface ServiceLocals {
   config: ConfigStore;
   meter: metrics.Meter;
   internalApp: Application<InternalLocals>;
+  traceId?: string;
 }
 
 export interface RequestLocals {


### PR DESCRIPTION
I broke the outgoing req log tracing losing correlation not realizing that telemetry is available on express-based instrumentation with incoming request, but not with SQS/cronjob related logs that are app-based and dont get telemetry info readily available.